### PR TITLE
[WALL] [POI/POA] Aum / poi-poa-2 / Initial setup for Flow modules

### DIFF
--- a/packages/wallets/src/features/accounts/index.ts
+++ b/packages/wallets/src/features/accounts/index.ts
@@ -1,1 +1,2 @@
+export * from './modules';
 export * from './screens';

--- a/packages/wallets/src/features/accounts/modules/DocumentService/DocumentService.tsx
+++ b/packages/wallets/src/features/accounts/modules/DocumentService/DocumentService.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ModalStepWrapper } from '../../../../components';
+
+const DocumentService = () => {
+    return <ModalStepWrapper />;
+};
+
+export default DocumentService;

--- a/packages/wallets/src/features/accounts/modules/DocumentService/index.ts
+++ b/packages/wallets/src/features/accounts/modules/DocumentService/index.ts
@@ -1,0 +1,1 @@
+export { default as DocumentService } from './DocumentService';

--- a/packages/wallets/src/features/accounts/modules/ManualService/ManualService.tsx
+++ b/packages/wallets/src/features/accounts/modules/ManualService/ManualService.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ModalStepWrapper } from '../../../../components';
+
+const ManualService = () => {
+    return <ModalStepWrapper />;
+};
+
+export default ManualService;

--- a/packages/wallets/src/features/accounts/modules/ManualService/index.ts
+++ b/packages/wallets/src/features/accounts/modules/ManualService/index.ts
@@ -1,0 +1,1 @@
+export { default as ManualService } from './ManualService';

--- a/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Poa = () => {
+    return <div />;
+};
+
+export default Poa;

--- a/packages/wallets/src/features/accounts/modules/Poa/index.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/index.ts
@@ -1,0 +1,1 @@
+export { default as Poa } from './Poa';

--- a/packages/wallets/src/features/accounts/modules/Poi/Poi.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poi/Poi.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Poi = () => {
+    return <div />;
+};
+
+export default Poi;

--- a/packages/wallets/src/features/accounts/modules/Poi/index.ts
+++ b/packages/wallets/src/features/accounts/modules/Poi/index.ts
@@ -1,0 +1,1 @@
+export { default as Poi } from './Poi';

--- a/packages/wallets/src/features/accounts/modules/TaxInformation/TaxInformation.tsx
+++ b/packages/wallets/src/features/accounts/modules/TaxInformation/TaxInformation.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TaxInformation = () => {
+    return <div />;
+};
+
+export default TaxInformation;

--- a/packages/wallets/src/features/accounts/modules/TaxInformation/index.ts
+++ b/packages/wallets/src/features/accounts/modules/TaxInformation/index.ts
@@ -1,0 +1,1 @@
+export { default as TaxInformation } from './TaxInformation';

--- a/packages/wallets/src/features/accounts/modules/index.ts
+++ b/packages/wallets/src/features/accounts/modules/index.ts
@@ -1,0 +1,3 @@
+export * from './DocumentService';
+export * from './Poi';
+export * from './TaxInformation';

--- a/packages/wallets/src/features/cfd/flows/ClientVerification/ClientVerification.tsx
+++ b/packages/wallets/src/features/cfd/flows/ClientVerification/ClientVerification.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ClientVerification = () => {
+    return <div />;
+};
+
+export default ClientVerification;

--- a/packages/wallets/src/features/cfd/flows/ClientVerification/index.ts
+++ b/packages/wallets/src/features/cfd/flows/ClientVerification/index.ts
@@ -1,0 +1,1 @@
+export { default as ClientVerification } from './ClientVerification';

--- a/packages/wallets/src/features/cfd/flows/index.ts
+++ b/packages/wallets/src/features/cfd/flows/index.ts
@@ -1,3 +1,4 @@
+export * from './ClientVerification';
 export * from './CTrader';
 export * from './MT5';
 export * from './OtherCFDs';


### PR DESCRIPTION
## Changes:

### Initial Setup for flow modules as follows:
1. **ClientVerification**: Flow controller for Poi, Poa and TaxInformation modules.
2. **Poi**: Flow controller for DocumentService and ManualService modules.
   a. **DocumentService**: Flow controller for IDV, Onfido and VerifyPersonalDetails components.
   b. **ManualService**: Flow controller for passport, driving-license, id-card, nimc components.
4. **Poa**: Poa form.
5. **TaxInformation**: TaxInformation form.
